### PR TITLE
chore: ignore .worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /assets-cache
 *.deb
 .idea/
+.worktrees/


### PR DESCRIPTION
Git worktrees create additional working directories inside the repository (e.g. .worktrees/fix-feature/).
These directories:
- contain files already tracked by Git, just checked out under a different branch;
- are only needed locally for parallel development;
- should never be committed, or they would pollute the repository history and git status.